### PR TITLE
Change leveldb and memcached URI scheme.

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -2,6 +2,11 @@
 
 # git master
 
+* [13](https://github.com/BlueBrain/Keyv/pull/13):
+  Change leveldb URI to
+  ```leveldb://[/namespace][?store=path_to_leveldb_dir]```
+  and memcached URI to
+  ```memcached://[host][:port][/namespace]```
 * [12](https://github.com/BlueBrain/Keyv/pull/12):
   Remove Map::fetch, superseeded by getValues and takeValues
 * [10](https://github.com/BlueBrain/Keyv/pull/10):

--- a/keyv/Map.cpp
+++ b/keyv/Map.cpp
@@ -119,8 +119,9 @@ MapPtr Map::createCache()
 #ifdef KEYV_USE_LEVELDB
     const char* leveldb = ::getenv( "LEVELDB_CACHE" );
     if( leveldb )
-        return MapPtr( new Map( servus::URI( std::string( "leveldb://" ) +
-                                             leveldb )));
+        return MapPtr( new Map( servus::URI(
+                                    std::string( "leveldb:///cache/?store=" ) +
+                                                 leveldb )));
 #endif
 
     return MapPtr();

--- a/tests/Map.cpp
+++ b/tests/Map.cpp
@@ -180,7 +180,8 @@ void setup( const std::string& uriStr )
     map.takeValues( keys, [&]( const std::string& key, char* data,
                                const size_t size )
     {
-        TESTINFO( std::find( keys.begin(), keys.end(), key) != keys.end(), key);
+        TESTINFO( std::find( keys.begin(), keys.end(), key ) != keys.end(),
+                  key );
         TEST( data );
         TESTINFO( size > 0, key << " in " << uriStr );
         ++numResults;
@@ -294,7 +295,7 @@ void testLevelDBFailures()
 #ifdef KEYV_USE_LEVELDB
     try
     {
-        setup( "leveldb:///doesnotexist/deadbeef/coffee" );
+        setup( "leveldb://?store=/doesnotexist/deadbeef/coffee" );
     }
     catch( const std::runtime_error& )
     {
@@ -334,7 +335,7 @@ int main( const int argc, char* argv[] )
 #ifdef KEYV_USE_LEVELDB
     tests.push_back( TestSpec( "", 0, 65536 ));
     tests.push_back( TestSpec( "leveldb://", 0, 65536 ));
-    tests.push_back( TestSpec( "leveldb://keyvMap2.leveldb", 0, 65536 ));
+    tests.push_back( TestSpec( "leveldb://?store=keyvMap2.leveldb", 0, 65536 ));
 #endif
 #ifdef KEYV_USE_LIBMEMCACHED
     if( testAvailable( "memcached://" ))


### PR DESCRIPTION
Uses now 'leveldb://[/namespace][?store=path_to_leveldb_dir]' to be
consistent with memcached. Will be documented in plugin description
following next. Needed for Bluebrain/Brion#123